### PR TITLE
Update printer.cfg

### DIFF
--- a/sovol/printer_data/config/printer.cfg
+++ b/sovol/printer_data/config/printer.cfg
@@ -246,8 +246,8 @@ check_gain_time:20
 hysteresis: 5                
 heating_gain: 2 
 
-[fan_generic fan0] # fan
-pin: extruder_mcu:PB0
+[fan_generic fan0] # part cooling fan
+pin: extruder_mcu:PA7
 max_power: 1.0
 cycle_time: 0.015
 
@@ -379,4 +379,5 @@ filename =/home/sovol/printer_data/config/saved_variables.cfg
 #*# 	3.770000:6019933.790,3.810000:6019533.418,3.850000:6019062.784,
 #*# 	3.890000:6018652.204,3.930000:6018254.172,3.970000:6017842.147,
 #*# 	4.010000:6017420.539,4.050000:6017150.998
+
 


### PR DESCRIPTION
Corrected [fan_generic fan0] pin definition. Pin PB0 is from the SV08 toolhead board for fan3. The Zero toolhead board uses PA7.
Added description of the fan in the comment.